### PR TITLE
Use URI form of proxy_pass instead of rewrite

### DIFF
--- a/reverse/proxy.conf
+++ b/reverse/proxy.conf
@@ -36,8 +36,7 @@ server {
 
     location / {
         if ($http_amp_cache_transform) {
-	    rewrite (.*) /priv/doc/$scheme://$server_name$request_uri break;
-	    proxy_pass http://amppkg;
+	    proxy_pass http://amppkg/priv/doc/$scheme://$server_name$request_uri;
 	}
         proxy_pass    http://origin;
     }


### PR DESCRIPTION
I believe this fixes an issue where a request for e.g. `/index%2ehtml` would get proxied as `/priv/doc/https://server/index.html`, and hence fail to adhere to [Google's SXG cache requirements](https://github.com/ampproject/amppackager/blob/releases/docs/cache_requirements.md).

If it's easy for you to verify this change on your own stack, I would appreciate it. I've made a similar change on my nginx server, but I'm just hand-editing the config file here, so I may have messed something up. If it's not easy, let me know, and I'll try do so on my own machine. Thanks!